### PR TITLE
Fix/remove approvedClaims field from subgraph query

### DIFF
--- a/src/graphql/subgraph.ts
+++ b/src/graphql/subgraph.ts
@@ -34,7 +34,6 @@ export const GET_VAULTS = gql`
           vestingHatPeriods
         }
         numberOfApprovedClaims
-        approvedClaims
         rewardsLevels
         totalRewardAmount
         liquidityPool


### PR DESCRIPTION
Due to this error - for now there is no use of this field in the dApp

![image](https://user-images.githubusercontent.com/34843014/153766784-c323bc1c-323e-4392-b58d-fd4a46915fb6.png)
