### PR TITLE
Fix member image not loading in vault editor

### DIFF
--- a/src/components/VaultEditor/CommitteeMember.tsx
+++ b/src/components/VaultEditor/CommitteeMember.tsx
@@ -2,20 +2,10 @@ import EditableContent from "components/CommitteeTools/components/EditableConten
 import { useTranslation } from "react-i18next";
 import IconInput from "./IconEditor";
 import RemoveIcon from "assets/icons/remove-member.svg";
-import { IPFS_PREFIX } from "../../constants/constants";
 
 export default function CommmitteeMember({ index, member, onChange, onRemove, membersCount, addMember }) {
     const { t } = useTranslation();
     const basePath = `committee.members.${index}`;
-
-    const verifyIPFSLink = (memberLink: string) => {
-        if (memberLink.startsWith("ipfs/")) {
-            return memberLink.slice(5);
-        } else if (memberLink.startsWith("ipfs://")) {
-            return memberLink.slice(7);
-        }
-        return memberLink;
-    }
 
     return <>
         <div className="committee-members__member">
@@ -60,13 +50,7 @@ export default function CommmitteeMember({ index, member, onChange, onRemove, me
                         <IconInput
                             name={`${basePath}.image-ipfs-link`}
                             colorable
-                            value={
-                                member?.["image-ipfs-link"]
-                                  ? member?.["image-ipfs-link"].startsWith("blob")
-                                    ? member?.["image-ipfs-link"]
-                                    : `${IPFS_PREFIX}${verifyIPFSLink(member?.["image-ipfs-link"])}`
-                                  : ""
-                            }
+                            value={member?.["image-ipfs-link"]}
                             onChange={onChange} />
                     </div>
                 </div>


### PR DESCRIPTION
Remove unnecessary use of `verifyIPFSLink` function and remove the function itself.