### PR TITLE
Refresh on network change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import AirdropPrompt from "components/AirdropMachine/components/AirdropPrompt/Ai
 import "./styles/App.scss";
 import { useCheckRedeemableNfts } from "components/AirdropMachine/utils";
 import EmbassyNotificationBar from "components/EmbassyNotificationBar/EmbassyNotificationBar";
+import { useOnNetworkChange } from "hooks/useOnNetworkChange";
 
 function App() {
   const dispatch = useDispatch();
@@ -54,6 +55,7 @@ function App() {
   });
 
   useCheckRedeemableNfts(toggleAirdropPrompt);
+  useOnNetworkChange();
 
   return (
     <>

--- a/src/hooks/useOnNetworkChange.ts
+++ b/src/hooks/useOnNetworkChange.ts
@@ -1,0 +1,15 @@
+import { ethers } from "ethers";
+
+export function useOnNetworkChange() {
+  // Force page refreshes on network changes
+  // The "any" network will allow spontaneous network changes
+  const provider = new ethers.providers.Web3Provider(window.ethereum, "any");
+  provider.on("network", (newNetwork, oldNetwork) => {
+    // When a Provider makes its initial connection, it emits a "network"
+    // event with a null oldNetwork along with the newNetwork. So, if the
+    // oldNetwork exists, it represents a changing network
+    if (oldNetwork) {
+      window.location.reload();
+    }
+  });
+}


### PR DESCRIPTION
This is in order to avoid current buggy situation after changing networks.
It's also described and recommended here:
https://docs.ethers.io/v5/concepts/best-practices/