### PR TITLE
Turn address to checksummed address

### DIFF
--- a/packages/shared/src/utils/gnosis.utils.ts
+++ b/packages/shared/src/utils/gnosis.utils.ts
@@ -1,6 +1,7 @@
 import { mainnet, goerli, optimism, arbitrum, polygon, avalanche, bsc } from "@wagmi/chains";
 import axios from "axios";
 import { isServer } from "./general.utils";
+import { utils } from "ethers";
 
 const getGnosisChainNameByChainId = (chainId: number): string => {
   switch (chainId) {
@@ -69,8 +70,9 @@ export const isAGnosisSafeTx = async (tx: string, chainId: number | undefined): 
 };
 
 const getGnosisSafeStatusApiEndpoint = (safeAddress: string, chainId: number): string => {
+  const checksummedSafeAddress = utils.getAddress(safeAddress);
   if (!chainId) return "";
-  return `https://safe-transaction-${getGnosisChainNameByChainId(chainId)}.safe.global/api/v1/safes/${safeAddress}`;
+  return `https://safe-transaction-${getGnosisChainNameByChainId(chainId)}.safe.global/api/v1/safes/${checksummedSafeAddress}`;
 };
 
 export const getGnosisSafeInfo = async (

--- a/packages/shared/src/utils/gnosis.utils.ts
+++ b/packages/shared/src/utils/gnosis.utils.ts
@@ -70,8 +70,8 @@ export const isAGnosisSafeTx = async (tx: string, chainId: number | undefined): 
 };
 
 const getGnosisSafeStatusApiEndpoint = (safeAddress: string, chainId: number): string => {
-  const checksummedSafeAddress = utils.getAddress(safeAddress);
   if (!chainId) return "";
+  const checksummedSafeAddress = utils.getAddress(safeAddress);
   return `https://safe-transaction-${getGnosisChainNameByChainId(chainId)}.safe.global/api/v1/safes/${checksummedSafeAddress}`;
 };
 


### PR DESCRIPTION
Safe validation is sensitive to addresses that are not passing the checksum test. This pr aims to fix that issue by turning the address to a checksummed address