### PR TITLE
Hotfix EditSession endpoint

### DIFF
--- a/packages/web/src/pages/VaultEditor/vaultEditorService.ts
+++ b/packages/web/src/pages/VaultEditor/vaultEditorService.ts
@@ -84,7 +84,7 @@ export async function upsertEditSession(
 export async function setEditSessionSubmittedToCreation(editSessionId: string | undefined): Promise<boolean> {
   if (!editSessionId) throw new Error("Edit session id is required");
 
-  const response = await axiosClient.get(`${BASE_SERVICE_URL}/edit-session/${editSessionId}/set-awaiting-creation`);
+  const response = await axiosClient.post(`${BASE_SERVICE_URL}/edit-session/${editSessionId}/set-awaiting-creation`);
 
   return response.data.ok;
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

## Release Notes

Bug fix: `setEditSessionSubmittedToCreation` function in `vaultEditorService.ts` now uses a POST request instead of a GET request.

> "From GET to POST,  
> A bug we did roast.  
> Code now runs smoother,  
> Thanks to this pull request's mover."
<!-- end of auto-generated comment: release notes by openai -->