### PR TITLE
fixed isMain selection functionality

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hats-finance/shared",
-  "version": "1.0.81",
+  "version": "1.0.82",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/src/types/editor.ts
+++ b/packages/shared/src/types/editor.ts
@@ -79,7 +79,7 @@ export interface IBaseEditedVaultDescription {
     "pgp-pk": string | string[];
   };
   scope: {
-    reposInformation?: IEditedRepoInformation[];
+    reposInformation: IEditedRepoInformation[];
   };
   "contracts-covered": IEditedContractCovered[];
   assets: IEditedVaultAsset[];


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Refactor: Modified the `IBaseEditedVaultDescription` interface to make the `reposInformation` property a required array of `IEditedRepoInformation`. Added a `useMemo` hook to memoize the `repos` array in `VaultDetailsForm.tsx`, which is derived from the `fields` and `watchFieldArray` arrays. Modified the logic for selecting the main repository when the list of repositories changes.

> "Code changes abound,
> Repositories now required,
> Memoized for speed."
<!-- end of auto-generated comment: release notes by openai -->