### PR TITLE
[Feature] Added Spiral DAO pricing function

### DIFF
--- a/packages/web/src/helpers/getContractPrices.ts
+++ b/packages/web/src/helpers/getContractPrices.ts
@@ -1,12 +1,14 @@
-import { BigNumber } from "ethers";
-import { mainnet } from "wagmi/chains";
-import { GoodDollar_abi, InsureDao_abi } from "@hats-finance/shared";
-import { readContract } from "wagmi/actions";
 import { formatUnits } from "@ethersproject/units";
+import { GoodDollar_abi, InsureDao_abi } from "@hats-finance/shared";
+import axios from "axios";
+import { BigNumber } from "ethers";
+import { readContract } from "wagmi/actions";
+import { mainnet } from "wagmi/chains";
 
 const InsureDAOTokenMainnet = "0x22453153978D0C25f86010c0fd405527feD9764b";
 const GoodDollarPriceContractMainnet = "0xa150a825d425B36329D8294eeF8bD0fE68f8F6E0";
 const GoodDollarTokenMainnet = "0x67c5870b4a41d4ebef24d2456547a03f1f3e094b";
+const SpiralDaoTokenMainnet = "0x85b6ACaBa696B9E4247175274F8263F99b4B9180";
 
 export const getGoodDollarPriceMainnet = async () => {
   const res = await readContract({
@@ -32,7 +34,16 @@ export const getInsureDAOPriceMainnet = async () => {
   return insureDaoPrice ? Number(formatUnits(insureDaoPrice)) : undefined;
 };
 
+export const getSpiralDaoPriceMainnet = async () => {
+  const apiRes = await axios.get("https://api.spiral.farm/data/eth/data");
+  if (apiRes.data?.rewardToken?.address.toLowerCase() !== SpiralDaoTokenMainnet.toLowerCase()) return undefined;
+
+  const spiralPrice = apiRes.data?.rewardToken?.price as number | undefined;
+  return spiralPrice;
+};
+
 export const tokenPriceFunctions = {
   [InsureDAOTokenMainnet.toLowerCase()]: getInsureDAOPriceMainnet,
   [GoodDollarTokenMainnet.toLowerCase()]: getGoodDollarPriceMainnet,
+  [SpiralDaoTokenMainnet.toLowerCase()]: getSpiralDaoPriceMainnet,
 };


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

New Feature: Added `getSpiralDaoPriceMainnet` function to retrieve the price of Spiral DAO token from an external API and added it to the `tokenPriceFunctions` object in `getContractPrices.ts`.

> "A new function we bring,
> To fetch the price of a DAO king.
> With this feature so neat,
> Our users' trades will be complete."
<!-- end of auto-generated comment: release notes by openai -->