### PR TITLE
[FIX] Fixed issues on the editor types (scope)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hats-finance/shared",
-  "version": "1.0.82",
+  "version": "1.0.83",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/src/types/editor.ts
+++ b/packages/shared/src/types/editor.ts
@@ -1,5 +1,11 @@
 import { BigNumber } from "ethers";
-import { ICommitteeMember, IVaultDescription, IVulnerabilitySeverityV1, IVulnerabilitySeverityV2 } from "./types";
+import {
+  ICommitteeMember,
+  IVaultDescription,
+  IVaultRepoInformation,
+  IVulnerabilitySeverityV1,
+  IVulnerabilitySeverityV2,
+} from "./types";
 
 export interface IEditedContractCovered {
   name: string;
@@ -10,12 +16,6 @@ export interface IEditedContractCovered {
 export interface IEditedCommunicationEmail {
   address: string;
   status: "verified" | "unverified" | "verifying";
-}
-
-export interface IEditedRepoInformation {
-  url: string;
-  commitHash: string;
-  isMain: boolean;
 }
 
 export interface IEditedVaultAsset {
@@ -78,8 +78,8 @@ export interface IBaseEditedVaultDescription {
   "communication-channel": {
     "pgp-pk": string | string[];
   };
-  scope: {
-    reposInformation: IEditedRepoInformation[];
+  scope?: {
+    reposInformation: IVaultRepoInformation[];
   };
   "contracts-covered": IEditedContractCovered[];
   assets: IEditedVaultAsset[];

--- a/packages/shared/src/types/types.ts
+++ b/packages/shared/src/types/types.ts
@@ -105,6 +105,9 @@ interface IBaseVaultDescription {
     members: Array<ICommitteeMember>;
     chainId?: string;
   };
+  scope?: {
+    reposInformation: IVaultRepoInformation[];
+  };
   source: {
     name: string;
     url: string;
@@ -133,6 +136,12 @@ export interface ICommitteeMember {
   "image-ipfs-link"?: string;
   linkedMultisigAddress?: string;
   "pgp-keys": Array<{ publicKey: string }>;
+}
+
+export interface IVaultRepoInformation {
+  url: string;
+  commitHash: string;
+  isMain: boolean;
 }
 
 export interface IBaseVulnerabilitySeverity {

--- a/packages/shared/src/utils/vaultEditor.utils.ts
+++ b/packages/shared/src/utils/vaultEditor.utils.ts
@@ -190,7 +190,6 @@ export function descriptionToEditedForm(vaultDescription: IVaultDescription, wit
       emails: withDefaultData ? [{ address: "", status: "unverified" as IEditedCommunicationEmail["status"] }] : [],
     },
     "contracts-covered": severitiesToContractsCoveredForm(severitiesWithIds),
-    scope: defaultDescription.scope,
     assets: defaultDescription.assets,
     parameters: defaultDescription.parameters,
     severitiesOptions,

--- a/packages/web/src/pages/VaultEditor/VaultEditorFormPage/SetupSteps/VaultDetailsForm/VaultDetailsForm.tsx
+++ b/packages/web/src/pages/VaultEditor/VaultEditorFormPage/SetupSteps/VaultDetailsForm/VaultDetailsForm.tsx
@@ -22,7 +22,7 @@ export function VaultDetailsForm() {
 
   const { register, control, resetField, setValue, getValues } = useEnhancedFormContext<IEditedVaultDescription>();
   const { fields, append: appendRepo, remove: removeRepo } = useFieldArray({ control, name: `scope.reposInformation` });
-  const watchFieldArray = useWatch({ control, name: `scope.reposInformation` });
+  const watchFieldArray = useWatch({ control, name: `scope.reposInformation`, defaultValue: [] });
   const repos = useMemo(
     () =>
       fields.map((field, index) => {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Added a new optional field `scope` to the `IBaseVaultDescription` interface.
- Refactor: Updated the import statement and replaced `IEditedRepoInformation` with `IVaultRepoInformation` in the `scope` property of the `IBaseEditedVaultDescription` interface.
- Refactor: Removed a line of code that sets the `scope` property to a default value in `vaultEditor.utils.ts`.
- Chore: Added a default value to the `useWatch` hook in `VaultDetailsForm.tsx`.

> "Code changes, big and small,
> OpenAI reviewed them all.
> Bugs were fixed, features added,
> Code quality was never degraded.
> Celebrate this PR, one and all!"
<!-- end of auto-generated comment: release notes by openai -->