### PR TITLE
Fix decimal issues with payouts

### DIFF
--- a/packages/shared/src/utils/payouts.utils.ts
+++ b/packages/shared/src/utils/payouts.utils.ts
@@ -104,21 +104,13 @@ export const getExecutePayoutSafeTransaction = async (
 
     const payoutData = payout.payoutData as ISplitPayoutData;
 
-    let exp = 3;
-
-    for (const beneficiary of payoutData.beneficiaries) {
-      const percentageOfPayoutSplittedStr = beneficiary.percentageOfPayout.toString().split(".");
-      if (percentageOfPayoutSplittedStr.length == 2 && percentageOfPayoutSplittedStr[1].length > exp) {
-        exp = percentageOfPayoutSplittedStr[1].length;
-      }
-    }
 
     // Payout payment splitter creation TX
     const encodedPaymentSplitterCreation = paymentSplitterFactoryContract.interface.encodeFunctionData(
       "createHATPaymentSplitter",
       [
         payoutData.beneficiaries.map((beneficiary) => beneficiary.beneficiary as `0x${string}`),
-        payoutData.beneficiaries.map((beneficiary) => BigNumber.from(Number(beneficiary.percentageOfPayout) * 10 ** exp)),
+        payoutData.beneficiaries.map((beneficiary) => BigNumber.from(Math.round(Number(beneficiary.percentageOfPayout) * 10 ** 10))),
       ]
     );
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Bug fix:
- Fixed decimal issues with payouts by rounding the percentage values to two decimal places and calculating the number of decimal places required for the payment splitter creation.

Bug fix:
- Fixed decimal issues with payouts by rounding off the percentage values to the nearest integer.

> Decimals fixed, payouts are sound,
> Bugs no more, we stand our ground.
<!-- end of auto-generated comment: release notes by openai -->