### PR TITLE
[Hotfix] Hash router only on IPFS

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -84,7 +84,8 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "react-app-rewired build"
+    "build": "react-app-rewired build && yarn sitemap",
+    "sitemap": "node ./sitemap-builder.js"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/web/sitemap-builder.js
+++ b/packages/web/sitemap-builder.js
@@ -1,0 +1,92 @@
+const fs = require("fs");
+
+const slugify = (str) =>
+  str
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+const query = `
+query {
+  vaults {
+    id
+    descriptionHash
+    registered
+  }
+}
+`;
+const subgraphs = [
+  "https://api.thegraph.com/subgraphs/name/hats-finance/hats",
+  "https://api.thegraph.com/subgraphs/name/hats-finance/hats_optimism",
+  // "https://api.thegraph.com/subgraphs/name/hats-finance/hats_goerli",
+  // "https://api.thegraph.com/subgraphs/name/hats-finance/hats_optimism_goerli",
+  "https://api.thegraph.com/subgraphs/name/hats-finance/hats_arbitrum",
+  "https://api.thegraph.com/subgraphs/name/hats-finance/hats_polygon",
+];
+const buildPath = "./build/sitemap.xml";
+const publicUrl = "https://app.hats.finance";
+const ipfsPrefix = "https://ipfs2.hats.finance/ipfs";
+
+const routes = [
+  { path: "/vaults/bug-bounties" },
+  { path: "/vaults/audit-competitions" },
+  { path: "/vulnerability" },
+  { path: "/vault-editor" },
+];
+
+const buildSitemap = async () => {
+  const subgraphPromises = subgraphs.map((subgraph) => {
+    return fetch(subgraph, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query }),
+    });
+  });
+  const subgraphResults = (
+    await Promise.all(subgraphPromises).then((responses) => Promise.all(responses.map((res) => res.json())))
+  )
+    .map((res) => res.data.vaults)
+    .flat()
+    .filter((vault) => vault.registered);
+  const descriptionHashes = subgraphResults.map((vault) => vault.descriptionHash);
+
+  const descriptionsPromises = descriptionHashes.map((descriptionHash) => {
+    return { hash: descriptionHash, promise: fetch(`${ipfsPrefix}/${descriptionHash}`) };
+  });
+  const descriptionsResults = await Promise.all(descriptionsPromises.map((desc) => desc.promise));
+  const descriptionsData = await Promise.all(descriptionsResults.map((res) => res.json()).map((p) => p.catch((e) => e)));
+  const descriptionsDataWithHash = descriptionsData.map((d) => ({ ...d, hash: descriptionHashes[descriptionsData.indexOf(d)] }));
+  const descriptions = descriptionsDataWithHash.filter((d) => !(d instanceof Error));
+  const vaultsRoutes = descriptions.map((d) => {
+    const vaultId = subgraphResults.find((vault) => vault.descriptionHash === d.hash).id;
+    const vaultSlug = slugify(d["project-metadata"]?.name ?? d["Project-metadata"]?.name ?? "");
+    const isAudit =
+      d["project-metadata"]?.type === "audit" ??
+      d["project-metadata"]?.type === "Audit Competition" ??
+      d["Project-metadata"]?.type === "audit" ??
+      d["Project-metadata"]?.type === "Audit Competition";
+
+    return { path: `/vaults/${isAudit ? "audit-competitions" : "bug-bounties"}/${vaultSlug}-${vaultId}` };
+  });
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  ${[...routes, ...vaultsRoutes].reduce(
+    (acc, route) => `${acc}
+    <url>
+      <loc>${publicUrl}${route.path}</loc>
+      <changefreq>daily</changefreq>
+      <priority>0.5</priority>
+    </url>`,
+    ""
+  )}
+  </urlset>
+  `;
+
+  fs.writeFileSync(buildPath, xml);
+  console.info(`> ✔️ Sitemap successfully generated at ${buildPath}`);
+};
+
+buildSitemap();

--- a/packages/web/src/application/Root.tsx
+++ b/packages/web/src/application/Root.tsx
@@ -14,7 +14,7 @@ import { useEffect } from "react";
 import HttpsRedirect from "react-https-redirect";
 import { useTranslation } from "react-i18next";
 import { Provider } from "react-redux";
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter, HashRouter } from "react-router-dom";
 import { GlobalStyle } from "styles";
 import { WagmiConfig } from "wagmi";
 import store from "../store";
@@ -27,6 +27,8 @@ function Root() {
     if (language && language !== i18n.language) i18n.changeLanguage(language);
   }, [i18n]);
 
+  const RouterToUse = document.location.pathname.startsWith("/ipfs/") ? HashRouter : BrowserRouter;
+
   return (
     <>
       <Seo isMainPage />
@@ -35,7 +37,7 @@ function Root() {
           <Provider store={store}>
             <VaultsProvider>
               <HttpsRedirect>
-                <HashRouter>
+                <RouterToUse>
                   <GlobalStyle />
                   <ThemeProvider theme={theme}>
                     <NotificationProvider>
@@ -48,7 +50,7 @@ function Root() {
                       </ConfirmDialogProvider>
                     </NotificationProvider>
                   </ThemeProvider>
-                </HashRouter>
+                </RouterToUse>
               </HttpsRedirect>
             </VaultsProvider>
           </Provider>

--- a/packages/web/src/navigation/AppRouter/AppRouter.tsx
+++ b/packages/web/src/navigation/AppRouter/AppRouter.tsx
@@ -1,20 +1,10 @@
-import { useEffect } from "react";
-import { RouteObject, useNavigate, useRoutes } from "react-router-dom";
+import { RouteObject, useRoutes } from "react-router-dom";
 
 interface LayoutsProps {
   routes: RouteObject[];
 }
 
 const AppRouter = ({ routes }: LayoutsProps): JSX.Element => {
-  const location = document.location;
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (location.pathname !== "/" && !location.hash.includes(location.pathname)) {
-      location.href = `${location.origin}/#${location.pathname}${location.search}`;
-    }
-  }, [navigate, location]);
-
   const appRoutes = useRoutes(routes);
 
   return <>{appRoutes}</>;

--- a/packages/web/src/navigation/AppRouter/AppRouter.tsx
+++ b/packages/web/src/navigation/AppRouter/AppRouter.tsx
@@ -10,4 +10,4 @@ const AppRouter = ({ routes }: LayoutsProps): JSX.Element => {
   return <>{appRoutes}</>;
 };
 
-export { AppRouter };
+export default AppRouter;

--- a/packages/web/src/navigation/AppRouter/index.ts
+++ b/packages/web/src/navigation/AppRouter/index.ts
@@ -1,1 +1,1 @@
-export { AppRouter } from './AppRouter';
+export { default as AppRouter } from "./AppRouter";

--- a/packages/web/src/navigation/routes.tsx
+++ b/packages/web/src/navigation/routes.tsx
@@ -1,5 +1,4 @@
 import { BasicLayout } from "layout";
-import { HoneypotsPage } from "pages";
 import { committeeToolsRouter } from "pages/CommitteeTools/router";
 import { honeypotsRouter } from "pages/Honeypots/router";
 import { submissionsRouter } from "pages/Submissions/router";
@@ -14,23 +13,6 @@ const routes: RouteObject[] = [
       {
         path: "/",
         element: <Navigate to={RoutePaths.vaults} replace={true} />,
-      },
-      {
-        path: `${RoutePaths.vaults}-old`,
-        children: [
-          {
-            path: "",
-            element: <HoneypotsPage />,
-          },
-          {
-            path: ":vaultId",
-            element: <HoneypotsPage />,
-          },
-          {
-            path: ":vaultId/deposit",
-            element: <HoneypotsPage showDeposit={true} />,
-          },
-        ],
       },
       honeypotsRouter(),
       submissionsRouter(),

--- a/packages/web/src/pages/Honeypots/VaultDetailsPage/Sections/VaultDepositsSection/HoldingsSection/components/VaultHoldings.tsx
+++ b/packages/web/src/pages/Honeypots/VaultDetailsPage/Sections/VaultDepositsSection/HoldingsSection/components/VaultHoldings.tsx
@@ -48,7 +48,7 @@ export const VaultHoldings = ({ vault }: VaultHoldingsProps) => {
 
   const getStatusPill = () => {
     if (isUserInQueueToWithdraw) {
-      const date = moment((withdrawStartTime ?? 0) * 1000).format("MMM Mo");
+      const date = moment((withdrawStartTime ?? 0) * 1000).format("MMM Do");
       const time = new Date((withdrawStartTime ?? 0) * 1000).toLocaleTimeString([], {
         hour: "2-digit",
         minute: "2-digit",
@@ -56,7 +56,7 @@ export const VaultHoldings = ({ vault }: VaultHoldingsProps) => {
       });
       return <Pill canMultiline dotColor="yellow" text={`${t("withdrawWindowWillOpenOn", { on: `${date} ${time}` })}`} />;
     } else if (isUserInTimeToWithdraw) {
-      const date = moment((withdrawEndTime ?? 0) * 1000).format("MMM Mo");
+      const date = moment((withdrawEndTime ?? 0) * 1000).format("MMM Do");
       const time = new Date((withdrawEndTime ?? 0) * 1000).toLocaleTimeString([], {
         hour: "2-digit",
         minute: "2-digit",

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowImportingTsExtensions": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    // "allowImportingTsExtensions": true,
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -23,7 +19,5 @@
     "noImplicitAny": false,
     "baseUrl": "src"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Refactor: Updated routing logic in `Root.tsx` and `AppRouter.tsx` to conditionally use either `HashRouter` or `BrowserRouter` based on the current URL path.
- Refactor: Modified date format in `VaultHoldings.tsx` from "MMM Mo" to "MMM Do".
- New Feature: Added `buildSitemap` function in `sitemap-builder.js` to generate an XML sitemap with routes for vaults and other paths.
- Refactor: Removed import statement for `HoneypotsPage` and eliminated a nested route configuration in `routes.tsx`.

> "Routing revamped, dates refined,
> Sitemap built, paths defined.
> Code transformed, bugs evicted,
> Release shines, users delighted!"
<!-- end of auto-generated comment: release notes by openai -->