### PR TITLE
[Hotfix] now showing 100% mas rewards on audit competitions

### DIFF
--- a/packages/web/src/hooks/severities/useSeverityRewardInfo.ts
+++ b/packages/web/src/hooks/severities/useSeverityRewardInfo.ts
@@ -17,14 +17,16 @@ export function useSeverityRewardInfo(vault: IVault | undefined, severityIndex: 
 
   if (!vault || !vault.description) return { rewardPrice: 0, rewardPercentage: 0, rewardColor: INITIAL_SEVERITY_COLOR };
 
-  const SEVERITIES_COLORS = getSeveritiesColorsArray(vault);
-
+  const isAudit = vault.description && vault.description["project-metadata"].type === "audit";
   const showIntendedAmounts = vault.amountsInfo?.showCompetitionIntendedAmount ?? false;
+  const SEVERITIES_COLORS = getSeveritiesColorsArray(vault);
 
   if (vault.version === "v2") {
     const severity = vault.description.severities[severityIndex];
     const sumTotalPrices = Object.values(totalPrices).reduce((a, b = 0) => a + b, 0);
-    const maxBountyPercentage = Number(vault.maxBounty) / 10000; // Number between 0 and 1;
+    // const maxBountyPercentage = Number(vault.maxBounty) / 10000; // Number between 0 and 1;
+    // TODO: remove this when we have the new vault contract version
+    const maxBountyPercentage = Number(isAudit ? 10000 : vault.maxBounty) / 10000;
     const rewardPercentage = +severity.percentage * maxBountyPercentage;
 
     let rewardPrice: number = 0;

--- a/packages/web/src/pages/Honeypots/VaultDetailsPage/Sections/VaultRewardsSection/VaultRewardsSection.tsx
+++ b/packages/web/src/pages/Honeypots/VaultDetailsPage/Sections/VaultRewardsSection/VaultRewardsSection.tsx
@@ -14,6 +14,7 @@ type VaultRewardsSectionProps = {
 
 export const VaultRewardsSection = ({ vault }: VaultRewardsSectionProps) => {
   const { t } = useTranslation();
+  const isAudit = vault.description && vault.description["project-metadata"].type === "audit";
 
   const showIntended = vault.amountsInfo?.showCompetitionIntendedAmount ?? false;
 
@@ -43,7 +44,14 @@ export const VaultRewardsSection = ({ vault }: VaultRewardsSectionProps) => {
                 <h4 className="value">~${millify(vault.amountsInfo?.competitionIntendedAmount?.maxReward.usd ?? 0)}</h4>
               </WithTooltip>
             ) : (
-              <h4 className="value">~${millify(vault.amountsInfo?.maxRewardAmount.usd ?? 0)}</h4>
+              // TODO: In here should be only the max reward amount, not the deposited amount
+              // Change this once we have the new contract version
+              <h4 className="value">
+                ~$
+                {isAudit
+                  ? millify(vault.amountsInfo?.depositedAmount.usd ?? 0)
+                  : millify(vault.amountsInfo?.maxRewardAmount.usd ?? 0)}
+              </h4>
             )}
           </div>
         </div>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
**New Feature**
- Added support for a new vault contract version in the web application.
- Modified the calculation of `maxBountyPercentage` in `useSeverityRewardInfo.ts` to accommodate audit vaults.
- Updated the display logic in `VaultRewardsSection.tsx` to show different reward amounts based on the type of vault.

> 🎉 A new vault version, oh what a sight! 🚀
> With calculations tweaked just right. 💡
> Displaying rewards, shining bright, ✨
> For every vault, day or night. 🌞🌜
```
<!-- end of auto-generated comment: release notes by openai -->