### PR TITLE
sanitizing submissions

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hats-finance/shared",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/src/constants/mdAllowedElements.ts
+++ b/packages/shared/src/constants/mdAllowedElements.ts
@@ -44,6 +44,6 @@ export const allowedElementsMarkdown = [
 ];
 
 export const allowedAttributesMarkdown = {
-  a: ["href", "name", "target", "class"],
+  a: ["href", "name", "class"],
   img: ["src", "alt", "class"],
 };

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -115,6 +115,7 @@
     "react-content-loader": "^6.2.1",
     "react-helmet": "^6.1.0",
     "react-identicons": "^1.2.5",
+    "sanitize-markdown": "^2.6.7",
     "siwe": "^1.1.6",
     "uuid-by-string": "^4.0.0"
   }

--- a/packages/web/src/pages/Submissions/SubmissionFormPage/FormSteps/SubmissionDescriptions/utils.ts
+++ b/packages/web/src/pages/Submissions/SubmissionFormPage/FormSteps/SubmissionDescriptions/utils.ts
@@ -1,3 +1,5 @@
+import { allowedAttributesMarkdown, allowedElementsMarkdown } from "@hats-finance/shared";
+import sanitizeMarkdown from "sanitize-markdown";
 import { BASE_SERVICE_URL } from "settings";
 import { ISubmissionData, ISubmissionsDescriptionsData } from "../../types";
 
@@ -58,7 +60,20 @@ ${
 
   const submissionMessage = `\`\`\`\n> [ENCRYPTED SECTION]\n\`\`\`\n\n${toEncrypt}\n\n\n \`\`\`\n> [DECRYPTED SECTION]\n\`\`\`\n\n${decrypted}`;
 
-  return { decrypted, toEncrypt, submissionMessage };
+  return {
+    decrypted: sanitizeMarkdown(decrypted, {
+      allowedTags: allowedElementsMarkdown,
+      allowedAttributes: allowedAttributesMarkdown,
+    }),
+    toEncrypt: sanitizeMarkdown(toEncrypt, {
+      allowedTags: allowedElementsMarkdown,
+      allowedAttributes: allowedAttributesMarkdown,
+    }),
+    submissionMessage: sanitizeMarkdown(submissionMessage, {
+      allowedTags: allowedElementsMarkdown,
+      allowedAttributes: allowedAttributesMarkdown,
+    }),
+  };
 };
 
 export const getBountySubmissionTexts = (
@@ -81,7 +96,17 @@ ${description.description.trim()}
 
   const submissionMessage = `\`\`\`\n> [ENCRYPTED SECTION]\n\`\`\`\n\n${toEncrypt}`;
 
-  return { decrypted: undefined, toEncrypt, submissionMessage };
+  return {
+    decrypted: undefined,
+    toEncrypt: sanitizeMarkdown(toEncrypt, {
+      allowedTags: allowedElementsMarkdown,
+      allowedAttributes: allowedAttributesMarkdown,
+    }),
+    submissionMessage: sanitizeMarkdown(submissionMessage, {
+      allowedTags: allowedElementsMarkdown,
+      allowedAttributes: allowedAttributesMarkdown,
+    }),
+  };
 };
 
 export const getGithubIssueDescription = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5179,6 +5179,11 @@ assertion-error@^1.1.0:
   resolved "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
+assignment@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/assignment/-/assignment-2.0.0.tgz#ffd17b21bf5d6b22e777b989681a815456a3dd3e"
+  integrity sha512-naMULXjtgCs9SVUEtyvJNt68aF18em7/W+dhbR59kbz9cXWPEvUkCun2tqlgqRPSqZaKPpqLc5ZnwL8jVmJRvw==
+
 ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz"
@@ -14577,6 +14582,13 @@ safe-stable-stringify@^2.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sanitize-markdown@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/sanitize-markdown/-/sanitize-markdown-2.6.7.tgz#335d7627fe15339cf5be5a0ae78590c097007e33"
+  integrity sha512-w0exIpQ6Zk/q4yUZNgYcxz5sO1o+y3zYeJlHXp+AGKUPOy9wUoKUpu6/+qVlW6oGMvQ72N/6Gx8q/tZG/CKxSA==
+  dependencies:
+    assignment "2.0.0"
 
 sanitize.css@*:
   version "13.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Security Enhancement: Introduced the use of `sanitize-markdown` library in `getSubmissionTexts` and `getBountySubmissionTexts` functions to sanitize markdown content, ensuring it only contains allowed tags and attributes. This prevents potential cross-site scripting (XSS) attacks.
- Refactor: Updated the `allowedAttributesMarkdown` object by removing the `"target"` attribute from the `<a>` element's allowed attributes. This change enhances security by preventing potential misuse of the `"target"` attribute.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->