### PR TITLE
[FIX] Fixed issue generation contracts based on repo in vault editor

### DIFF
--- a/packages/web/src/pages/VaultEditor/VaultEditorFormPage/SetupSteps/ScopeDetailsForm/ContractsCoveredList/ContractsCoveredList.tsx
+++ b/packages/web/src/pages/VaultEditor/VaultEditorFormPage/SetupSteps/ScopeDetailsForm/ContractsCoveredList/ContractsCoveredList.tsx
@@ -53,7 +53,7 @@ export function ContractsCoveredList() {
     append(
       contractsToCreate.map((contract) => ({
         name: "",
-        severities: [],
+        severities: severitiesFormIds,
         link: "",
         address: contract.path,
         linesOfCode: contract.lines,
@@ -78,7 +78,7 @@ export function ContractsCoveredList() {
       confirmText: t("gotIt"),
     });
     // console.log(a);
-  }, [reposInfo, validRepos, append, t, confirm]);
+  }, [severitiesFormIds, reposInfo, validRepos, append, t, confirm]);
 
   return (
     <>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the `ContractsCoveredList` component in the Vault Editor to correctly assign severity levels to each contract. Previously, contracts were created with an empty severity array, which has now been fixed to use the appropriate `severitiesFormIds`. This ensures that each contract is associated with the correct severity level, enhancing the accuracy and usability of the contract management feature.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->