### PR TITLE
now showing finished private comps on the general finished audits

### DIFF
--- a/packages/web/src/pages/Honeypots/VaultsPage/hooks.ts
+++ b/packages/web/src/pages/Honeypots/VaultsPage/hooks.ts
@@ -61,7 +61,9 @@ export const useAuditCompetitionsVaults = (opts: { private: boolean } = { privat
         (whiteAddress) => whiteAddress.address.toLowerCase() === profileData?.address?.toLowerCase()
       );
 
-      return opts.private ? isPrivateAudit && (isUserInvited || isGovMember) : !isPrivateAudit;
+      return opts.private
+        ? isPrivateAudit && (isUserInvited || isGovMember)
+        : !isPrivateAudit || payout.payoutData?.vault?.dateStatus === "finished";
     });
 
   auditCompetitionsVaults.sort((a, b) => (b.amountsInfo?.depositedAmount.usd ?? 0) - (a.amountsInfo?.depositedAmount.usd ?? 0));


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the `useAuditCompetitionsVaults` function in the Honeypots Vault Page. The function now correctly includes audits with a "finished" vault status when the audit is not private. This change ensures that all relevant data is accurately represented to the user, improving the overall functionality and reliability of the application.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->