### PR TITLE
[Fix] Override Hats and Smooth vaults governance fee

### DIFF
--- a/packages/web/src/hooks/subgraph/vaults/parser.ts
+++ b/packages/web/src/hooks/subgraph/vaults/parser.ts
@@ -18,6 +18,15 @@ export const parseUserNfts = (userNfts: IUserNft[], chainId: number) => {
 };
 
 export const parseVaults = (vaults: IVault[], chainId: number) => {
+  // Override the default governance fee (we already changed it on-chain, but takes time to show up)
+  const newVaults = [...vaults];
+  // Smooth by Dappnode
+  const smoothVault = newVaults.find((vault) => vault.id.toLowerCase() === "0x64bc275b37e62eec81a00ecaecd2b9567058f990");
+  if (smoothVault) smoothVault.governanceHatRewardSplit = "2000";
+  // Hats Arbitrator Audit Competition
+  const hatsVault = newVaults.find((vault) => vault.id.toLowerCase() === "0x79a618f675857b45934ca1c413fd5f409cf89735");
+  if (hatsVault) hatsVault.governanceHatRewardSplit = "0";
+
   return vaults.map((vault) => ({
     ...vault,
     chainId,


### PR DESCRIPTION
We already changed it on-chain, but takes time to show up.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Bug Fix: Updated the governance fee for two specific vaults to reflect recent on-chain changes. The vault with ID "0x64bc275b37e62eec81a00ecaecd2b9567058f990" now has a `governanceHatRewardSplit` of "2000", and the vault with ID "0x79a618f675857b45934ca1c413fd5f409cf89735" has a `governanceHatRewardSplit` of "0". This ensures that the displayed fees are accurate and up-to-date.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->