### PR TITLE
[FIX] Getting UMA voting token price from mainnet

### DIFF
--- a/packages/web/src/helpers/getContractPrices.ts
+++ b/packages/web/src/helpers/getContractPrices.ts
@@ -2,6 +2,7 @@ import { formatUnits } from "@ethersproject/units";
 import { GoodDollar_abi, InsureDao_abi } from "@hats.finance/shared";
 import axios from "axios";
 import { BigNumber } from "ethers";
+import { getCoingeckoTokensPrices } from "utils/tokens.utils";
 import { readContract } from "wagmi/actions";
 import { mainnet } from "wagmi/chains";
 
@@ -9,6 +10,7 @@ const InsureDAOTokenMainnet = "0x22453153978D0C25f86010c0fd405527feD9764b";
 const GoodDollarPriceContractMainnet = "0xa150a825d425B36329D8294eeF8bD0fE68f8F6E0";
 const GoodDollarTokenMainnet = "0x67c5870b4a41d4ebef24d2456547a03f1f3e094b";
 const SpiralDaoTokenMainnet = "0x85b6ACaBa696B9E4247175274F8263F99b4B9180";
+const UMAVotingTokenOP = "0xe7798f023fc62146e8aa1b36da45fb70855a77ea";
 
 export const externalPricingProvidersUrls = {
   spiraldao: "https://api.spiral.farm/data/eth/data",
@@ -46,8 +48,16 @@ export const getSpiralDaoPriceMainnet = async () => {
   return spiralPrice;
 };
 
+export const getUMAVotingPriceOP = async () => {
+  const UMATokenMainnet = "0x04fa0d235c4abf4bcf4787af4cf447de572ef828";
+  const apiRes = await getCoingeckoTokensPrices([{ address: UMATokenMainnet, chainId: 1 }]);
+
+  return apiRes[UMATokenMainnet.toLowerCase()]?.["usd"] as number | undefined;
+};
+
 export const tokenPriceFunctions = {
   [InsureDAOTokenMainnet.toLowerCase()]: getInsureDAOPriceMainnet,
   [GoodDollarTokenMainnet.toLowerCase()]: getGoodDollarPriceMainnet,
   [SpiralDaoTokenMainnet.toLowerCase()]: getSpiralDaoPriceMainnet,
+  [UMAVotingTokenOP.toLowerCase()]: getUMAVotingPriceOP,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a function to fetch UMA Voting token prices from Coingecko.
  - Enhanced token price functionalities to support UMA Voting tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->