### PR TITLE
fix: `useUserHasCollectedSignature` not depending on `account` anymore

### DIFF
--- a/packages/web/src/pages/Honeypots/VaultDetailsPage/hooks.ts
+++ b/packages/web/src/pages/Honeypots/VaultDetailsPage/hooks.ts
@@ -49,7 +49,7 @@ export const useUserHasCollectedSignature = (vault: IVault | undefined): UseQuer
       }
     },
     refetchOnWindowFocus: false,
-    enabled: !!vault && !!account,
+    enabled: !!vault,
   });
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the user signature collection process by enabling the relevant functionality when a valid vault is provided, regardless of the account state.

- **Bug Fixes**
	- Resolved issues where the signature collection hook was not enabled due to missing account information, improving user experience in accessing vault details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->