### PR TITLE
fix: if no deposit, address to deposit is ZERO

### DIFF
--- a/packages/web/src/pages/Airdrops/contracts/RedeemMultipleAirdropsContract.ts
+++ b/packages/web/src/pages/Airdrops/contracts/RedeemMultipleAirdropsContract.ts
@@ -67,7 +67,11 @@ export class RedeemMultipleAirdropsContract {
             return proof;
           });
           const proofs = await Promise.all(proofsPromises);
-          const vaults = airdrops.map((_) => (vaultToDeposit ?? "0x0000000000000000000000000000000000000000") as `0x${string}`);
+          const vaults = airdrops.map((_) =>
+            percentageToDeposit === 0
+              ? "0x0000000000000000000000000000000000000000"
+              : ((vaultToDeposit ?? "0x0000000000000000000000000000000000000000") as `0x${string}`)
+          );
           const deposits = airdropsEligibility.map((eligibility) => {
             if (!eligibility) return BigNumber.from(0);
             const total = +formatUnits(eligibility.total, 18);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced logic for determining vault values during multiple airdrop redemption, ensuring that vault addresses are set appropriately based on deposit percentages.
  
- **Bug Fixes**
  - Corrected handling of vault values to prevent unintended zero address assignments when no vault is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->